### PR TITLE
Restore search text on device rotation

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -15,6 +15,7 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
+        <option name="useQualifiedModuleNames" value="true" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,9 @@ android {
     dataBinding {
         enabled = true
     }
+    kotlinOptions {
+        jvmTarget = '1.8'
+    }
 }
 
 dependencies {

--- a/app/src/main/java/com/avs/moviefinder/di/GenericSavedStateViewModelFactory.kt
+++ b/app/src/main/java/com/avs/moviefinder/di/GenericSavedStateViewModelFactory.kt
@@ -1,0 +1,22 @@
+package com.avs.moviefinder.di
+
+import android.os.Bundle
+import androidx.lifecycle.AbstractSavedStateViewModelFactory
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.savedstate.SavedStateRegistryOwner
+
+class GenericSavedStateViewModelFactory<out V : ViewModel>(
+    private val viewModelFactory: ViewModelAssistedFactory<V>,
+    owner: SavedStateRegistryOwner,
+    defaultArgs: Bundle? = null
+) : AbstractSavedStateViewModelFactory(owner, defaultArgs) {
+
+    override fun <T : ViewModel?> create(
+        key: String,
+        modelClass: Class<T>,
+        handle: SavedStateHandle
+    ): T {
+        return viewModelFactory.create(handle) as T
+    }
+}

--- a/app/src/main/java/com/avs/moviefinder/di/MainViewModelFactory.kt
+++ b/app/src/main/java/com/avs/moviefinder/di/MainViewModelFactory.kt
@@ -1,0 +1,14 @@
+package com.avs.moviefinder.di
+
+import androidx.lifecycle.SavedStateHandle
+import com.avs.moviefinder.ui.main.MainViewModel
+import com.avs.moviefinder.utils.RxBus
+import javax.inject.Inject
+
+class MainViewModelFactory @Inject constructor(
+    val rxBus: RxBus
+) : ViewModelAssistedFactory<MainViewModel> {
+    override fun create(handle: SavedStateHandle): MainViewModel {
+        return MainViewModel(rxBus, handle)
+    }
+}

--- a/app/src/main/java/com/avs/moviefinder/di/ViewModelAssistedFactory.kt
+++ b/app/src/main/java/com/avs/moviefinder/di/ViewModelAssistedFactory.kt
@@ -1,0 +1,8 @@
+package com.avs.moviefinder.di
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+
+interface ViewModelAssistedFactory<T: ViewModel> {
+    fun create(handle: SavedStateHandle): T
+}

--- a/app/src/main/java/com/avs/moviefinder/di/ViewModelsModule.kt
+++ b/app/src/main/java/com/avs/moviefinder/di/ViewModelsModule.kt
@@ -21,11 +21,6 @@ abstract class ViewModelsModule {
 
     @Binds
     @IntoMap
-    @ViewModelKey(MainViewModel::class)
-    internal abstract fun mainViewModel(viewModel: MainViewModel): ViewModel
-
-    @Binds
-    @IntoMap
     @ViewModelKey(MovieViewModel::class)
     internal abstract fun movieViewModel(viewModel: MovieViewModel): ViewModel
 

--- a/app/src/main/java/com/avs/moviefinder/ui/main/MainViewModel.kt
+++ b/app/src/main/java/com/avs/moviefinder/ui/main/MainViewModel.kt
@@ -1,14 +1,19 @@
 package com.avs.moviefinder.ui.main
 
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import com.avs.moviefinder.network.dto.Query
 import com.avs.moviefinder.utils.RxBus
 import io.reactivex.disposables.Disposable
-import javax.inject.Inject
 
-class MainViewModel @Inject constructor(
-    private val rxBus: RxBus
+class MainViewModel constructor(
+    private val rxBus: RxBus,
+    private val handle: SavedStateHandle
 ) : ViewModel() {
+
+    companion object {
+        val KEY_SEARCH_QUERY = "KEY_SEARCH_QUERY"
+    }
 
     private var apiDisposable: Disposable? = null
 
@@ -19,6 +24,8 @@ class MainViewModel @Inject constructor(
 
     fun onQueryTextSubmit(newText: String) {
         rxBus.send(Query(newText))
-        // todo fix rotation search bar issue
     }
+
+    fun onQueryTextChanged(newText: String) = handle.set(KEY_SEARCH_QUERY, newText)
+    fun getLatestQueryTest(): String? = handle.get<String>(KEY_SEARCH_QUERY)
 }


### PR DESCRIPTION
[https://proandroiddev.com/saving-ui-state-with-viewmodel-savedstate-and-dagger-f77bcaeb8b08](https://proandroiddev.com/saving-ui-state-with-viewmodel-savedstate-and-dagger-f77bcaeb8b08)

@AlinaStepanova I would suggest taking some of these changes further to the rest of the ViewModels so you can use lifecycle and SaveStateHandle functionality across all view models in the app. 
